### PR TITLE
Fixes dark LaTeX blocks

### DIFF
--- a/background.css
+++ b/background.css
@@ -11,8 +11,8 @@ div.mwe-math-element {
 
 div, table, th, body, nav, tbody, li, ul, input, abbr, a, caption, b {
   background-color: #0d1117 !important; /* Dark coloring */
-}
 
+}
 h1, h2, h3, h4, p, th, td, div, li, input, span, i, caption, .oo-ui-labelWidget {
   color: #c9d1d9 !important; /* Light grey coloring, e.g. headlines */
 }
@@ -54,7 +54,7 @@ pre, code, .hll, tr::before {
   color: #c9d1d9 !important; /* White grey coloring */
 }
 
-img.mwe-math-fallback-image-inline, .helpContents-icon img {
+img.mwe-math-fallback-image-inline, img.mwe-math-fallback-image-display, .helpContents-icon img {
     filter: invert(90%) !important;
 }
 


### PR DESCRIPTION
Hello. This pull request fixes the issue with dark blocks of LaTeX mentioned in #14.

After some digging around in Wikipedia's CSS it seems there are two types of LaTeX blocks: image-inline and image-display. Originally the extension only adjusted the color of the inline blocks.

This PR adds display blocks as well and is tested to be working on Firefox 95.0.2 on Arch Linux.

I've never made a pull request before so please let me know if I am missing anything. Thanks!