### PR TITLE
Change lang. button fix & bottom icons

### DIFF
--- a/background.css
+++ b/background.css
@@ -90,10 +90,10 @@ span.mw-ui-button, td[style*="text-align:center;background:#f0f0f0"], td[style*=
 th.infobox-above, th.summary, div[id*="ooui-php-498"], td[style*="background:#f0f0f0"], div.quotebox-title, td[style*="background:#dddddd"], td[style*="background:lightgrey"], 
 td[style*="background:silver"],
 /*Buttons*/
-a[class*="mw-ui-button"] {
+a[class*="mw-ui-button"], button[class*="mw-interlanguage-selector"]{ 
   background-color: #21262d !important;
+  color: #c9d1d9 !important;
 }
-
 /* LIGHT BLUE (CLICKABLE TEXT) */
 a, .tocnumber, .toctext, label.toctogglelabel, span.toctext i {
   color: #58a6ff !important;
@@ -166,6 +166,11 @@ span[class^="s"], span:is(.nn, .c, .nv) {
 td.table-partial, 
 span:is(.c1, .cm, .o, .mi, .mf, .fm) {
   color: #b2b4b6 !important;
+}
+
+#footer-icons{
+  background-color: #f2eee8 !important;
+  filter: invert(1);
 }
 
 a.mw-wiki-logo {


### PR DESCRIPTION
## The footer icon change can be discarded if you don't like it
- Changed the "more langs" button on the left sidebar to match other buttons style
<img width="187" alt="More langs button before" src="https://user-images.githubusercontent.com/36245871/199066305-feb5aa66-52f2-4097-a87c-b8c3c1b87e5a.png">
<img width="345" alt=" langs button after" src="https://user-images.githubusercontent.com/36245871/199066861-1f91e456-64a3-43c9-bd49-1013bbd8c8bf.png">

- Inverted the "a Wikimedia Project" and other icons placed at footer of page.
<img width="903" alt="Footer Icons before " src="https://user-images.githubusercontent.com/36245871/199066394-d0766fa9-b91c-4c09-81b1-f7cbf273c2e5.png">
<img width="568" alt="Footer Icons after" src="https://user-images.githubusercontent.com/36245871/199066782-c94f4b6e-77b5-4c4c-80de-8ad96244462c.png">
