### PR TITLE
Fix gradient fade element not working on firefox

### DIFF
--- a/background.css
+++ b/background.css
@@ -183,7 +183,7 @@ a.mw-wiki-logo {
 }
 
 /* SVG FADE ELEMENT INSIDE TABLE OF CONTENTS */
-#vector-toc::after {
+div#vector-toc.vector-toc.vector-pinnable-element::after {
   background: linear-gradient(rgba(255,255,255,0),#0d1117);
 }
 


### PR DESCRIPTION
The changes I previously made don't work on firefox, so I added an extended CSS selector to fix it