### PR TITLE
Better support for red green yellow table coloring 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Or:
 - [X] [Coloring on table](https://en.wikipedia.org/wiki/Democracy_Index#By_region)
 - [X] [Progress bars](https://en.wikipedia.org/wiki/2018_Swedish_general_election#Parties)
 - [X] [Pie chart](https://en.wikipedia.org/wiki/Wikipedia#Language_editions)
-- [X] [Red green table coloring](https://en.wikipedia.org/wiki/Nordic_Defence_Cooperation#Limitations)
+- [X] [Red green yellow table coloring](https://en.wikipedia.org/wiki/Nordic_Defence_Cooperation#Limitations)
 - [X] [Element "span" grey coloring](https://en.wikipedia.org/wiki/Affricate)
 
 ## Wall of Fame 🏆

--- a/background.css
+++ b/background.css
@@ -147,10 +147,13 @@ span[class*="icon-add"], ins {
 /* CODE SYNTAX TEXT COLORS */
 a.new, 
 td.table-no, td[style*="background:#F6E4E7"],
-span:is(.kd, .kn) {
+td.table-no > p, td[style*="background:#F6E4E7"] > p,
+span:is(.kd, .kn),
+span:is(.kd, .kn) > p {
   color: #FF7B72 !important;
 }
-td.table-yes, td[style*="background:#D4F7D4"] {
+td.table-yes, td[style*="background:#D4F7D4"],
+td.table-yes > p, td[style*="background:#D4F7D4"] > p {
   color: #46a559 !important;
 }
 span:is(.na, .k, .nb, .kr, .vg) {
@@ -166,9 +169,11 @@ span:is(.nc, .nf, .kt) {
 span[class^="s"], span:is(.nn, .c, .nv) {
   color: #A5D6FF !important;
 }
-td.table-partial, 
-span:is(.c1, .cm, .o, .mi, .mf, .fm) {
-  color: #b2b4b6 !important;
+td.table-partial, td.table-maybe, td[style*="background:#FFB"], td[style*="background:#FFFFBB"],
+td.table-partial > p, td.table-maybe > p, td[style*="background:#FFB"] > p, td[style*="background:#FFFFBB"] > p,
+span:is(.c1, .cm, .o, .mi, .mf, .fm),
+span:is(.c1, .cm, .o, .mi, .mf, .fm) > p {
+  color: #F6B511 !important;
 }
 
 #footer-icons {


### PR DESCRIPTION
I noticed that table-partial and  table-maybe colors are not colored properly.
Also table-yes and table-no were sometimes not fully colored.
**Before**
![Before](https://github.com/hirschan/Dark-Mode-Wikipedia/assets/29606657/4ce4b0ef-91e5-4984-927b-759ecef6b21f)
**After**
![After](https://github.com/hirschan/Dark-Mode-Wikipedia/assets/29606657/ba036b20-b6c7-43b5-bf92-36c706fa8751)
**Before**
![Before](https://github.com/hirschan/Dark-Mode-Wikipedia/assets/29606657/eaedf0c5-0752-4e3a-9358-927f954d9508)
**After**
![After](https://github.com/hirschan/Dark-Mode-Wikipedia/assets/29606657/8354d57d-d4b7-487b-b7c2-d432458f61a9)

