### PR TITLE
Add rule for popup text fade

### DIFF
--- a/background.css
+++ b/background.css
@@ -197,6 +197,11 @@ div#vector-page-tools.vector-page-tools.vector-pinnable-element::after {
   background: linear-gradient(rgba(255,255,255,0),#0d1117);
 }
 
+/* FIX POPUP TEXT FADE */
+.mwe-popups .mwe-popups-extract[dir='ltr']::after{
+  background-image:linear-gradient(to right, rgba(13,17,23,0), #0d1117 50%) !important;
+}
+
 /* INVERTS COLOR OF LOGO, TAGLINE, AND VARIOUS ICONS */
 img.mw-logo-wordmark, img.mw-logo-tagline, .mw-ext-score>img, .central-textlogo__image, .uls-add-languages-button, .uls-search-label, .uls-language-actions-close,
 .mw-ui-icon-wikimedia-fullScreen, .mw-ui-icon-wikimedia-exitFullscreen, .mw-ui-icon-wikimedia-menu, .mw-ui-icon-wikimedia-ellipsis, .mw-ui-icon-wikimedia-listBullet,


### PR DESCRIPTION
The popup for links to different pages contains a gradient block in the bottom-right in the form of an ::after pseudo element to make it seem the text fades into the (white) background. It really stands out with this dark mode extension, which this commit fixes.