### PR TITLE
Exclude images from getting their background set to black

### DIFF
--- a/background.css
+++ b/background.css
@@ -23,7 +23,8 @@ Read more here: https://www.w3schools.com/css/css_attribute_selectors.asp
 *:not(tr, td, div[style*="background-color"], div > div > span, td > div > span, div, a[class*="mw-tmh-play"],
 /* Text in tables: */ td > span, td > b, td > a, td > sub,
 /* Screenshot & Foxy Gesture bug fix #41: */ iframe, canvas,
-/* Color scheme under images, e.g: https://en.wikipedia.org/wiki/2023_Israel%E2%80%93Hamas_war#Invasion_of_the_Gaza_Strip_(27_October%E2%80%93present) */ span[class*="legend-color"]) {
+/* Color scheme under images, e.g: https://en.wikipedia.org/wiki/2023_Israel%E2%80%93Hamas_war#Invasion_of_the_Gaza_Strip_(27_October%E2%80%93present) */ span[class*="legend-color"], 
+  img[class*=mw-file-element]) {
   background-color: #0d1117 !important;
 }
 

--- a/background.css
+++ b/background.css
@@ -24,7 +24,7 @@ Read more here: https://www.w3schools.com/css/css_attribute_selectors.asp
 /* Text in tables: */ td > span, td > b, td > a, td > sub,
 /* Screenshot & Foxy Gesture bug fix #41: */ iframe, canvas,
 /* Color scheme under images, e.g: https://en.wikipedia.org/wiki/2023_Israel%E2%80%93Hamas_war#Invasion_of_the_Gaza_Strip_(27_October%E2%80%93present) */ span[class*="legend-color"], 
-/* Images */ img[class*=mw-file-element]) {
+/* Images */ img[class*="mw-file-element"]) {
   background-color: #0d1117 !important;
 }
 

--- a/background.css
+++ b/background.css
@@ -24,9 +24,11 @@ Read more here: https://www.w3schools.com/css/css_attribute_selectors.asp
 /* Text in tables: */ td > span, td > b, td > a, td > sub,
 /* Screenshot & Foxy Gesture bug fix #41: */ iframe, canvas,
 /* Color scheme under images, e.g: https://en.wikipedia.org/wiki/2023_Israel%E2%80%93Hamas_war#Invasion_of_the_Gaza_Strip_(27_October%E2%80%93present) */ span[class*="legend-color"], 
-  img[class*=mw-file-element]) {
+/* Images */ img[class*=mw-file-element]) {
   background-color: #0d1117 !important;
 }
+
+
 
 /* AVOID: div[class*="mw"] and div since it causes black bug (GitHub issue #10) */
 div[class*="mw-page-container"], div[class*="vector-header-container"], div[id*="vector-main-menu"], div[id*="vector-toc"], div[id*="mp"], div[class*="side"], div[class*="thumb"],


### PR DESCRIPTION
Many images with a transparent background are created with a white background in mind, which are not readable with this extension. For example from https://en.wikipedia.org/wiki/Low-pass_filter: 
![Screenshot 2024-05-07 205442](https://github.com/hirschan/Dark-Mode-Wikipedia/assets/28624123/ef879ad8-fef0-47ee-bc6b-4c58d275757f)
I added the img tag to the list of elements which automatically get their background-color set to black, which fixes this problem for many images. 
![image](https://github.com/hirschan/Dark-Mode-Wikipedia/assets/28624123/20ea06aa-aae1-402b-acc4-b77729e2996a)